### PR TITLE
feat: Add simple hello_world example for Level 1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ download-data: data/rogets_thesaurus.pdf ## Download all sample data
 
 download-all: download-data download-philosophy ## Download all texts (thesaurus + philosophy)
 
+run-hello-world: ## Run the Hello World example
+	$(UV) run python -m src.examples.hello_world
+
 run-rag-pipeline: ## Run the RAG pipeline demo
 	$(UV) run python -m src.rag.pipeline
 

--- a/README.org
+++ b/README.org
@@ -134,6 +134,13 @@ Our workshop materials are in .org format (plain text files) containing:
 
 Each notebook contains executable Python code blocks. You can run them in several ways:
 
+**** Option 0: Basic Python Verification
+Before diving into more complex examples, you can run a simple "Hello, World!" script to quickly verify your Python environment and project setup:
+#+BEGIN_SRC shell
+make run-hello-world
+#+END_SRC
+This command executes a basic script located in =src/examples/hello_world.py=. If this runs successfully, your Python setup is likely correct for Level 1.
+
 **** Option 1: Direct Python Execution
 #+BEGIN_SRC shell
 # Extract code from org files

--- a/src/examples/hello_world.py
+++ b/src/examples/hello_world.py
@@ -1,0 +1,10 @@
+# src/examples/hello_world.py
+
+def greet(name: str = "World") -> str:
+    """Returns a greeting message."""
+    message = f"Hello, {name}! Your Python environment is working."
+    print(message)
+    return message
+
+if __name__ == "__main__":
+    greet()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,34 @@
+# tests/test_examples.py
+
+import unittest
+from unittest.mock import patch
+import io
+
+from src.examples import hello_world
+
+class TestExamples(unittest.TestCase):
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_hello_world_output(self, mock_stdout):
+        # Call the function that prints to stdout
+        message = hello_world.greet("TestUser")
+        
+        # Check the printed output
+        self.assertEqual(mock_stdout.getvalue().strip(), "Hello, TestUser! Your Python environment is working.")
+        
+        # Check the returned message
+        self.assertEqual(message, "Hello, TestUser! Your Python environment is working.")
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_hello_world_default_output(self, mock_stdout):
+        # Call the function with default argument
+        message = hello_world.greet()
+        
+        # Check the printed output
+        self.assertEqual(mock_stdout.getvalue().strip(), "Hello, World! Your Python environment is working.")
+        
+        # Check the returned message
+        self.assertEqual(message, "Hello, World! Your Python environment is working.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a basic "Hello, World!" Python script, a corresponding Makefile target, and unit tests. It also updates the README to guide you to this example as an initial check for your Python environment.

The main changes include:
- Added `src/examples/hello_world.py`: A simple script that prints a greeting.
- Added `src/examples/__init__.py`: To make `examples` a Python package.
- Added `run-hello-world` target to `Makefile`: Allows easy execution via `make run-hello-world`.
- Added `tests/test_examples.py`: Contains unit tests for the `hello_world` script.
- Updated `README.org`: Included "Option 0: Basic Python Verification" to highlight the new example as a first step for you.

This enhances Level 1 support by providing a minimal, straightforward way for you to confirm your Python setup is working correctly before proceeding to more complex examples in the workshop.